### PR TITLE
chore: prepare for public release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
 name: CI
 
-# TODO: Switch back to ubuntu-latest when billing is resolved
 # This workflow is safe for external PRs (forks):
 # - No secrets are used
 # - Permissions are read-only
@@ -22,7 +21,7 @@ concurrency:
 jobs:
   lint:
     name: Lint
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -45,7 +44,7 @@ jobs:
 
   typecheck:
     name: Type Check
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: lint
     continue-on-error: true  # Temporarily soft-fail until the codebase is fully strict
     steps:
@@ -67,7 +66,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: lint
     strategy:
       fail-fast: false
@@ -99,7 +98,7 @@ jobs:
 
   security:
     name: Security Scan
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: lint
     steps:
       - uses: actions/checkout@v4
@@ -128,7 +127,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [lint, typecheck, test, security]
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "merlya"
 version = "0.5.6"
 description = "Merlya - AI-powered infrastructure assistant"
 authors = [
-    { name = "Cedric", email = "cedric@example.com" }
+    { name = "Cedric", email = "infra@merlya.fr" }
 ]
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

- Update author email to infra@merlya.fr in pyproject.toml
- Switch CI from self-hosted to GitHub-hosted runners (ubuntu-latest)
- Remove TODO comment about billing

## Context

Preparation for the public open source release of Merlya.

## Test plan

- [ ] CI passes on GitHub-hosted runners
- [ ] Package builds correctly